### PR TITLE
debug empty image made plugin crash

### DIFF
--- a/owl-carousel/owl.carousel.js
+++ b/owl-carousel/owl.carousel.js
@@ -1253,7 +1253,7 @@ if (typeof Object.create !== "function") {
             }
             naturalWidthType = typeof img.naturalWidth;
             if (naturalWidthType !== "undefined" && img.naturalWidth === 0) {
-                return false;
+                return true;
             }
             return true;
         },


### PR DESCRIPTION
if there are multiple images in a slide, if one of them is empty (like <img/> tag), the plugin is unable to calculate height.